### PR TITLE
[FEAT] Auth 관련 연동 코드 작성 

### DIFF
--- a/app/src/main/java/com/moduro/barrier_free_app/app/di/DataSourceModule.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/app/di/DataSourceModule.kt
@@ -1,10 +1,12 @@
 package com.moduro.barrier_free_app.app.di
 
 import com.moduro.barrier_free_app.data.datasource.AirKoreaDataSource
+import com.moduro.barrier_free_app.data.datasource.AuthDataSource
 import com.moduro.barrier_free_app.data.datasource.ExampleDataSource
 import com.moduro.barrier_free_app.data.datasource.LocationNameDataSource
 import com.moduro.barrier_free_app.data.datasource.LocationTempDataSource
 import com.moduro.barrier_free_app.data.datasourceimpl.AirKoreaDataSourceImpl
+import com.moduro.barrier_free_app.data.datasourceimpl.AuthDataSourceImpl
 import com.moduro.barrier_free_app.data.datasourceimpl.ExampleDataSourceImpl
 import com.moduro.barrier_free_app.data.datasourceimpl.LocationNameDataSourceImpl
 import com.moduro.barrier_free_app.data.datasourceimpl.LocationTempDataSourceImpl
@@ -34,4 +36,7 @@ abstract class DataSourceModule {
     @Singleton
     abstract fun bindLocationNameDataSource(locationNameDataSourceImpl: LocationNameDataSourceImpl) : LocationNameDataSource
 
+    @Binds
+    @Singleton
+    abstract fun bindAuthDataSource(authDataSourceImpl: AuthDataSourceImpl) : AuthDataSource
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/app/di/RepositoryModule.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/app/di/RepositoryModule.kt
@@ -2,10 +2,12 @@ package com.moduro.barrier_free_app.app.di
 
 
 import com.moduro.barrier_free_app.data.repositoryimpl.AirKoreaRepositoryImpl
+import com.moduro.barrier_free_app.data.repositoryimpl.AuthRepositoryImpl
 import com.moduro.barrier_free_app.data.repositoryimpl.ExampleRepositoryImpl
 import com.moduro.barrier_free_app.data.repositoryimpl.LocationNameRepositoryImpl
 import com.moduro.barrier_free_app.data.repositoryimpl.LocationTempRepositoryImpl
 import com.moduro.barrier_free_app.domain.repository.AirKoreaRepository
+import com.moduro.barrier_free_app.domain.repository.AuthRepository
 import com.moduro.barrier_free_app.domain.repository.ExampleRepository
 import com.moduro.barrier_free_app.domain.repository.LocationNameRepository
 import com.moduro.barrier_free_app.domain.repository.LocationTempRepository
@@ -36,4 +38,7 @@ abstract class RepositoryModule {
     @Singleton
     abstract fun bindLocationNameRepository(locationNameRepositoryImpl: LocationNameRepositoryImpl) : LocationNameRepository
 
+    @Binds
+    @Singleton
+    abstract fun bindAuthRepository(authRepositoryImpl: AuthRepositoryImpl) : AuthRepository
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/app/di/RetrofitModule.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/app/di/RetrofitModule.kt
@@ -1,5 +1,7 @@
 package com.moduro.barrier_free_app.app.di
 
+import android.content.Context
+import android.content.SharedPreferences
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.moduro.barrier_free_app.BuildConfig
 import com.moduro.barrier_free_app.app.interceptor.LocationNameTokenInterceptor
@@ -7,6 +9,7 @@ import com.moduro.barrier_free_app.app.interceptor.TokenInterceptor
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
@@ -27,6 +30,15 @@ object RetrofitModule {
         return HttpLoggingInterceptor().apply {
             level = HttpLoggingInterceptor.Level.BODY
         }
+    }
+
+    // Shared Preferences 제공
+    @Provides
+    @Singleton
+    fun provideSharedPreferences(
+        @ApplicationContext context: Context
+    ): SharedPreferences {
+        return context.getSharedPreferences("MODURO_PREFS", Context.MODE_PRIVATE)
     }
 
     @Provides

--- a/app/src/main/java/com/moduro/barrier_free_app/app/di/ServiceModule.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/app/di/ServiceModule.kt
@@ -1,6 +1,7 @@
 package com.moduro.barrier_free_app.app.di
 
 import com.moduro.barrier_free_app.data.service.AirKoreaApiService
+import com.moduro.barrier_free_app.data.service.AuthApiService
 import com.moduro.barrier_free_app.data.service.ExampleApiService
 import com.moduro.barrier_free_app.data.service.LocationNameApiService
 import com.moduro.barrier_free_app.data.service.LocationTempApiService
@@ -39,4 +40,9 @@ object ServiceModule {
         @LocationNameRetrofit retrofit: Retrofit
     ) : LocationNameApiService = retrofit.create(LocationNameApiService::class.java)
 
+    @Provides
+    @Singleton
+    fun provideAuthService(
+        @ModuroRetrofit retrofit: Retrofit
+    ) : AuthApiService = retrofit.create(AuthApiService::class.java)
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/app/interceptor/Tokeninterceptor.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/app/interceptor/Tokeninterceptor.kt
@@ -1,15 +1,24 @@
 package com.moduro.barrier_free_app.app.interceptor
 
+import android.content.SharedPreferences
+import android.util.Log
 import okhttp3.Interceptor
 import okhttp3.Response
 import javax.inject.Inject
 
-class TokenInterceptor @Inject constructor() : Interceptor {
+class TokenInterceptor @Inject constructor(private val preferences: SharedPreferences) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
-        val originalRequest = chain.request()
-        val newRequest = originalRequest.newBuilder()
-            .addHeader("Authorization", "Bearer your_token_here") // 임시 토큰
-            .build()
-        return chain.proceed(newRequest)
+        val prefs = preferences
+        val token = prefs.getString("USER_TOKEN", null)
+
+        Log.d("TokenInterceptor", "Retrieved Token: $token")
+
+        val request = chain.request().newBuilder().apply {
+            token?.let {
+                addHeader("Authorization", "Bearer $it")
+            }
+        }.build()
+
+        return chain.proceed(request)
     }
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/core_ui/component/IdDuplicateTextField.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/core_ui/component/IdDuplicateTextField.kt
@@ -1,0 +1,110 @@
+package com.moduro.barrier_free_app.core_ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color.Companion.Transparent
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.moduro.barrier_free_app.core_ui.theme.Background1
+import com.moduro.barrier_free_app.core_ui.theme.Button1
+import com.moduro.barrier_free_app.core_ui.theme.LocalbarrierFreeTypographyProvider
+import com.moduro.barrier_free_app.core_ui.theme.Text3
+import com.moduro.barrier_free_app.core_ui.theme.Text4
+
+@Composable
+fun IdDuplicateTextField(
+    label: String,
+    hint: String,
+    text: String,
+    onValueChange: (String) -> Unit,
+    enabled: Boolean,
+    onCheckDuplicateClick: () -> Unit
+) {
+    val typography = LocalbarrierFreeTypographyProvider.current
+
+    Column(
+        modifier = Modifier
+            .clip(RoundedCornerShape(10.dp))
+            .fillMaxWidth()
+            .background(color = Background1)
+    ) {
+        Text(
+            text = label,
+            style = typography.H9_M,
+            modifier = Modifier.padding(start = 14.dp, top = 11.dp)
+        )
+        Box(
+            modifier = Modifier.clip(RoundedCornerShape(10.dp))
+                .background(Background1)
+        ) {
+            TextField(
+                value = text,
+                onValueChange = onValueChange,
+                placeholder = {
+                    Text(hint, style = typography.H5_SB_10, color = Text3)
+                },
+                trailingIcon = {
+                    Surface(
+                        shape = RoundedCornerShape(6.dp),
+                        color = Button1,
+                        modifier = Modifier
+                            .padding(end = 8.dp)
+                            .height(30.dp)
+                            .wrapContentWidth()
+                            .clickable { onCheckDuplicateClick() }
+                    ) {
+                        Box(
+                            contentAlignment = Alignment.Center,
+                            modifier = Modifier.padding(horizontal = 8.dp)
+                        ) {
+                            Text(
+                                text = "중복 확인",
+                                style = typography.H10_M
+                            )
+                        }
+                    }
+                },
+                enabled = enabled,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(55.dp),
+                colors = TextFieldDefaults.colors(
+                    focusedContainerColor = Background1,
+                    unfocusedContainerColor = Background1,
+                    disabledContainerColor = Background1,
+                    disabledIndicatorColor = Transparent
+                ),
+                textStyle = typography.H5_SB_5.copy(color = Text4)
+            )
+        }
+    }
+
+}
+
+@Composable
+@Preview
+fun IdDuplicateTextFieldPreview() {
+    IdDuplicateTextField(
+        label = "이메일 주소",
+        hint = "아이디 또는 이메일 주소",
+        text = "",
+        onValueChange = {},
+        onCheckDuplicateClick = {},
+        enabled = true
+    )
+}

--- a/app/src/main/java/com/moduro/barrier_free_app/data/datasource/AuthDataSource.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/datasource/AuthDataSource.kt
@@ -1,9 +1,12 @@
 package com.moduro.barrier_free_app.data.datasource
 
 import com.moduro.barrier_free_app.data.dto.ModuroBaseResponse
+import com.moduro.barrier_free_app.data.dto.request.LoginRequestDto
 import com.moduro.barrier_free_app.data.dto.request.SignUpRequestDto
 import kotlinx.serialization.json.JsonElement
 
 interface AuthDataSource {
     suspend fun signup(signUpRequestDto: SignUpRequestDto) : ModuroBaseResponse<JsonElement>
+
+    suspend fun login(loginRequestDto: LoginRequestDto) : ModuroBaseResponse<JsonElement>
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/data/datasource/AuthDataSource.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/datasource/AuthDataSource.kt
@@ -17,4 +17,6 @@ interface AuthDataSource {
     suspend fun send(emailRequestDto: EmailRequestDto) : ModuroBaseResponse<JsonElement>
 
     suspend fun verify(verifyRequestDto: VerifyRequestDto) : ModuroBaseResponse<JsonElement>
+
+    suspend fun duplicate(type: String, input: String) : ModuroBaseResponse<JsonElement>
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/data/datasource/AuthDataSource.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/datasource/AuthDataSource.kt
@@ -1,6 +1,7 @@
 package com.moduro.barrier_free_app.data.datasource
 
 import com.moduro.barrier_free_app.data.dto.ModuroBaseResponse
+import com.moduro.barrier_free_app.data.dto.request.FindRequestDto
 import com.moduro.barrier_free_app.data.dto.request.LoginRequestDto
 import com.moduro.barrier_free_app.data.dto.request.SignUpRequestDto
 import kotlinx.serialization.json.JsonElement
@@ -9,4 +10,6 @@ interface AuthDataSource {
     suspend fun signup(signUpRequestDto: SignUpRequestDto) : ModuroBaseResponse<JsonElement>
 
     suspend fun login(loginRequestDto: LoginRequestDto) : ModuroBaseResponse<JsonElement>
+
+    suspend fun find(type: String, findRequestDto: FindRequestDto) : ModuroBaseResponse<JsonElement>
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/data/datasource/AuthDataSource.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/datasource/AuthDataSource.kt
@@ -1,9 +1,10 @@
 package com.moduro.barrier_free_app.data.datasource
 
 import com.moduro.barrier_free_app.data.dto.ModuroBaseResponse
-import com.moduro.barrier_free_app.data.dto.request.FindRequestDto
+import com.moduro.barrier_free_app.data.dto.request.EmailRequestDto
 import com.moduro.barrier_free_app.data.dto.request.LoginRequestDto
 import com.moduro.barrier_free_app.data.dto.request.SignUpRequestDto
+import com.moduro.barrier_free_app.data.dto.request.VerifyRequestDto
 import kotlinx.serialization.json.JsonElement
 
 interface AuthDataSource {
@@ -11,5 +12,9 @@ interface AuthDataSource {
 
     suspend fun login(loginRequestDto: LoginRequestDto) : ModuroBaseResponse<JsonElement>
 
-    suspend fun find(type: String, findRequestDto: FindRequestDto) : ModuroBaseResponse<JsonElement>
+    suspend fun find(type: String, emailRequestDto: EmailRequestDto) : ModuroBaseResponse<JsonElement>
+
+    suspend fun send(emailRequestDto: EmailRequestDto) : ModuroBaseResponse<JsonElement>
+
+    suspend fun verify(verifyRequestDto: VerifyRequestDto) : ModuroBaseResponse<JsonElement>
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/data/datasource/AuthDataSource.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/datasource/AuthDataSource.kt
@@ -5,12 +5,13 @@ import com.moduro.barrier_free_app.data.dto.request.EmailRequestDto
 import com.moduro.barrier_free_app.data.dto.request.LoginRequestDto
 import com.moduro.barrier_free_app.data.dto.request.SignUpRequestDto
 import com.moduro.barrier_free_app.data.dto.request.VerifyRequestDto
+import com.moduro.barrier_free_app.data.dto.response.LoginResponseDto
 import kotlinx.serialization.json.JsonElement
 
 interface AuthDataSource {
     suspend fun signup(signUpRequestDto: SignUpRequestDto) : ModuroBaseResponse<JsonElement>
 
-    suspend fun login(loginRequestDto: LoginRequestDto) : ModuroBaseResponse<JsonElement>
+    suspend fun login(loginRequestDto: LoginRequestDto) : ModuroBaseResponse<LoginResponseDto>
 
     suspend fun find(type: String, emailRequestDto: EmailRequestDto) : ModuroBaseResponse<JsonElement>
 

--- a/app/src/main/java/com/moduro/barrier_free_app/data/datasource/AuthDataSource.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/datasource/AuthDataSource.kt
@@ -1,0 +1,9 @@
+package com.moduro.barrier_free_app.data.datasource
+
+import com.moduro.barrier_free_app.data.dto.ModuroBaseResponse
+import com.moduro.barrier_free_app.data.dto.request.SignUpRequestDto
+import kotlinx.serialization.json.JsonElement
+
+interface AuthDataSource {
+    suspend fun signup(signUpRequestDto: SignUpRequestDto) : ModuroBaseResponse<JsonElement>
+}

--- a/app/src/main/java/com/moduro/barrier_free_app/data/datasourceimpl/AuthDataSourceImpl.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/datasourceimpl/AuthDataSourceImpl.kt
@@ -32,4 +32,8 @@ class AuthDataSourceImpl @Inject constructor(
     override suspend fun verify(verifyRequestDto: VerifyRequestDto): ModuroBaseResponse<JsonElement> {
         return authApiService.verify(verifyRequestDto)
     }
+
+    override suspend fun duplicate(type: String, input: String): ModuroBaseResponse<JsonElement> {
+        return authApiService.duplicate(type, input)
+    }
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/data/datasourceimpl/AuthDataSourceImpl.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/datasourceimpl/AuthDataSourceImpl.kt
@@ -2,9 +2,10 @@ package com.moduro.barrier_free_app.data.datasourceimpl
 
 import com.moduro.barrier_free_app.data.datasource.AuthDataSource
 import com.moduro.barrier_free_app.data.dto.ModuroBaseResponse
-import com.moduro.barrier_free_app.data.dto.request.FindRequestDto
+import com.moduro.barrier_free_app.data.dto.request.EmailRequestDto
 import com.moduro.barrier_free_app.data.dto.request.LoginRequestDto
 import com.moduro.barrier_free_app.data.dto.request.SignUpRequestDto
+import com.moduro.barrier_free_app.data.dto.request.VerifyRequestDto
 import com.moduro.barrier_free_app.data.service.AuthApiService
 import kotlinx.serialization.json.JsonElement
 import javax.inject.Inject
@@ -20,7 +21,15 @@ class AuthDataSourceImpl @Inject constructor(
         return authApiService.login(loginRequestDto)
     }
 
-    override suspend fun find(type: String, findRequestDto: FindRequestDto): ModuroBaseResponse<JsonElement> {
-        return authApiService.find(type, findRequestDto)
+    override suspend fun find(type: String, emailRequestDto: EmailRequestDto): ModuroBaseResponse<JsonElement> {
+        return authApiService.find(type, emailRequestDto)
+    }
+
+    override suspend fun send(emailRequestDto: EmailRequestDto): ModuroBaseResponse<JsonElement> {
+        return authApiService.send(emailRequestDto)
+    }
+
+    override suspend fun verify(verifyRequestDto: VerifyRequestDto): ModuroBaseResponse<JsonElement> {
+        return authApiService.verify(verifyRequestDto)
     }
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/data/datasourceimpl/AuthDataSourceImpl.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/datasourceimpl/AuthDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.moduro.barrier_free_app.data.datasourceimpl
 
 import com.moduro.barrier_free_app.data.datasource.AuthDataSource
 import com.moduro.barrier_free_app.data.dto.ModuroBaseResponse
+import com.moduro.barrier_free_app.data.dto.request.FindRequestDto
 import com.moduro.barrier_free_app.data.dto.request.LoginRequestDto
 import com.moduro.barrier_free_app.data.dto.request.SignUpRequestDto
 import com.moduro.barrier_free_app.data.service.AuthApiService
@@ -17,5 +18,9 @@ class AuthDataSourceImpl @Inject constructor(
 
     override suspend fun login(loginRequestDto: LoginRequestDto): ModuroBaseResponse<JsonElement> {
         return authApiService.login(loginRequestDto)
+    }
+
+    override suspend fun find(type: String, findRequestDto: FindRequestDto): ModuroBaseResponse<JsonElement> {
+        return authApiService.find(type, findRequestDto)
     }
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/data/datasourceimpl/AuthDataSourceImpl.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/datasourceimpl/AuthDataSourceImpl.kt
@@ -6,6 +6,7 @@ import com.moduro.barrier_free_app.data.dto.request.EmailRequestDto
 import com.moduro.barrier_free_app.data.dto.request.LoginRequestDto
 import com.moduro.barrier_free_app.data.dto.request.SignUpRequestDto
 import com.moduro.barrier_free_app.data.dto.request.VerifyRequestDto
+import com.moduro.barrier_free_app.data.dto.response.LoginResponseDto
 import com.moduro.barrier_free_app.data.service.AuthApiService
 import kotlinx.serialization.json.JsonElement
 import javax.inject.Inject
@@ -17,7 +18,7 @@ class AuthDataSourceImpl @Inject constructor(
         return authApiService.signup(signUpRequestDto)
     }
 
-    override suspend fun login(loginRequestDto: LoginRequestDto): ModuroBaseResponse<JsonElement> {
+    override suspend fun login(loginRequestDto: LoginRequestDto): ModuroBaseResponse<LoginResponseDto> {
         return authApiService.login(loginRequestDto)
     }
 

--- a/app/src/main/java/com/moduro/barrier_free_app/data/datasourceimpl/AuthDataSourceImpl.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/datasourceimpl/AuthDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.moduro.barrier_free_app.data.datasourceimpl
 
 import com.moduro.barrier_free_app.data.datasource.AuthDataSource
 import com.moduro.barrier_free_app.data.dto.ModuroBaseResponse
+import com.moduro.barrier_free_app.data.dto.request.LoginRequestDto
 import com.moduro.barrier_free_app.data.dto.request.SignUpRequestDto
 import com.moduro.barrier_free_app.data.service.AuthApiService
 import kotlinx.serialization.json.JsonElement
@@ -12,5 +13,9 @@ class AuthDataSourceImpl @Inject constructor(
 ) : AuthDataSource {
     override suspend fun signup(signUpRequestDto: SignUpRequestDto): ModuroBaseResponse<JsonElement> {
         return authApiService.signup(signUpRequestDto)
+    }
+
+    override suspend fun login(loginRequestDto: LoginRequestDto): ModuroBaseResponse<JsonElement> {
+        return authApiService.login(loginRequestDto)
     }
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/data/datasourceimpl/AuthDataSourceImpl.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/datasourceimpl/AuthDataSourceImpl.kt
@@ -1,0 +1,16 @@
+package com.moduro.barrier_free_app.data.datasourceimpl
+
+import com.moduro.barrier_free_app.data.datasource.AuthDataSource
+import com.moduro.barrier_free_app.data.dto.ModuroBaseResponse
+import com.moduro.barrier_free_app.data.dto.request.SignUpRequestDto
+import com.moduro.barrier_free_app.data.service.AuthApiService
+import kotlinx.serialization.json.JsonElement
+import javax.inject.Inject
+
+class AuthDataSourceImpl @Inject constructor(
+    private val authApiService: AuthApiService
+) : AuthDataSource {
+    override suspend fun signup(signUpRequestDto: SignUpRequestDto): ModuroBaseResponse<JsonElement> {
+        return authApiService.signup(signUpRequestDto)
+    }
+}

--- a/app/src/main/java/com/moduro/barrier_free_app/data/dto/request/EmailRequestDto.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/dto/request/EmailRequestDto.kt
@@ -1,0 +1,9 @@
+package com.moduro.barrier_free_app.data.dto.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EmailRequestDto (
+    @SerialName("email") val email: String
+)

--- a/app/src/main/java/com/moduro/barrier_free_app/data/dto/request/FindRequestDto.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/dto/request/FindRequestDto.kt
@@ -1,0 +1,9 @@
+package com.moduro.barrier_free_app.data.dto.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FindRequestDto (
+    @SerialName("email") val email: String
+)

--- a/app/src/main/java/com/moduro/barrier_free_app/data/dto/request/LoginRequestDto.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/dto/request/LoginRequestDto.kt
@@ -1,0 +1,10 @@
+package com.moduro.barrier_free_app.data.dto.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class LoginRequestDto (
+    @SerialName("username") val username: String,
+    @SerialName("password") val password: String
+)

--- a/app/src/main/java/com/moduro/barrier_free_app/data/dto/request/SignUpRequestDto.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/dto/request/SignUpRequestDto.kt
@@ -1,0 +1,15 @@
+package com.moduro.barrier_free_app.data.dto.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SignUpRequestDto (
+    @SerialName("email") val email: String,
+    @SerialName("nickname") val nickname: String,
+    @SerialName("username") val username: String,
+    @SerialName("password") val password: String,
+    @SerialName("verifyPassword") val verifyPassword: String,
+    @SerialName("userType") val userType: String,
+    @SerialName("userFacilityIds") val userFacilityIds: List<Int>
+)

--- a/app/src/main/java/com/moduro/barrier_free_app/data/dto/request/VerifyRequestDto.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/dto/request/VerifyRequestDto.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class FindRequestDto (
-    @SerialName("email") val email: String
+data class VerifyRequestDto (
+    @SerialName("email") val email: String,
+    @SerialName("verificationCode") val verificationCode: String
 )

--- a/app/src/main/java/com/moduro/barrier_free_app/data/dto/response/LoginResponseDto.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/dto/response/LoginResponseDto.kt
@@ -1,0 +1,11 @@
+package com.moduro.barrier_free_app.data.dto.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class LoginResponseDto (
+    @SerialName("userId") val userId: Long,
+    @SerialName("accessToken") val accessToken: String,
+    @SerialName("refreshToken") val refreshToken: String
+)

--- a/app/src/main/java/com/moduro/barrier_free_app/data/repositoryimpl/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/repositoryimpl/AuthRepositoryImpl.kt
@@ -90,4 +90,16 @@ class AuthRepositoryImpl @Inject constructor(
             result
         }
     }
+
+    override suspend fun duplicate(type: String, input: String): Result<JsonElement> {
+        return kotlin.runCatching {
+            val response = authDataSource.duplicate(
+                type = type,
+                input = input
+            )
+            val result = response.result ?: throw Exception("result is null")
+
+            result
+        }
+    }
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/data/repositoryimpl/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/repositoryimpl/AuthRepositoryImpl.kt
@@ -1,9 +1,10 @@
 package com.moduro.barrier_free_app.data.repositoryimpl
 
 import com.moduro.barrier_free_app.data.datasource.AuthDataSource
-import com.moduro.barrier_free_app.data.dto.request.FindRequestDto
+import com.moduro.barrier_free_app.data.dto.request.EmailRequestDto
 import com.moduro.barrier_free_app.data.dto.request.LoginRequestDto
 import com.moduro.barrier_free_app.data.dto.request.SignUpRequestDto
+import com.moduro.barrier_free_app.data.dto.request.VerifyRequestDto
 import com.moduro.barrier_free_app.domain.repository.AuthRepository
 import kotlinx.serialization.json.JsonElement
 import javax.inject.Inject
@@ -60,7 +61,29 @@ class AuthRepositoryImpl @Inject constructor(
         return kotlin.runCatching {
             val response = authDataSource.find(
                 type = type,
-                FindRequestDto(email = email)
+                EmailRequestDto(email = email)
+            )
+            val result = response.result ?: throw Exception("result is null")
+
+            result
+        }
+    }
+
+    override suspend fun send(email: String): Result<JsonElement> {
+        return kotlin.runCatching {
+            val response = authDataSource.send(
+                EmailRequestDto(email = email)
+            )
+            val result = response.result ?: throw Exception("result is null")
+
+            result
+        }
+    }
+
+    override suspend fun verify(email: String, verificationCode: String): Result<JsonElement> {
+        return kotlin.runCatching {
+            val response = authDataSource.verify(
+                VerifyRequestDto(email = email, verificationCode = verificationCode)
             )
             val result = response.result ?: throw Exception("result is null")
 

--- a/app/src/main/java/com/moduro/barrier_free_app/data/repositoryimpl/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/repositoryimpl/AuthRepositoryImpl.kt
@@ -1,0 +1,39 @@
+package com.moduro.barrier_free_app.data.repositoryimpl
+
+import com.moduro.barrier_free_app.data.datasource.AuthDataSource
+import com.moduro.barrier_free_app.data.dto.request.SignUpRequestDto
+import com.moduro.barrier_free_app.domain.repository.AuthRepository
+import kotlinx.serialization.json.JsonElement
+import javax.inject.Inject
+
+class AuthRepositoryImpl @Inject constructor(
+    private val authDataSource: AuthDataSource
+) : AuthRepository {
+
+    override suspend fun signup(
+        email: String,
+        nickname: String,
+        username: String,
+        password: String,
+        verifyPassword: String,
+        userType: String,
+        userFacilityIds: List<Int>
+    ): Result<JsonElement> {
+        return kotlin.runCatching {
+            val response = authDataSource.signup(
+                SignUpRequestDto(
+                    email = email,
+                    nickname = nickname,
+                    username = username,
+                    password = password,
+                    verifyPassword = verifyPassword,
+                    userType = userType,
+                    userFacilityIds = userFacilityIds
+                )
+            )
+            val result = response.result ?: throw Exception("result is null")
+
+            result
+        }
+    }
+}

--- a/app/src/main/java/com/moduro/barrier_free_app/data/repositoryimpl/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/repositoryimpl/AuthRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.moduro.barrier_free_app.data.repositoryimpl
 
 import com.moduro.barrier_free_app.data.datasource.AuthDataSource
+import com.moduro.barrier_free_app.data.dto.request.FindRequestDto
 import com.moduro.barrier_free_app.data.dto.request.LoginRequestDto
 import com.moduro.barrier_free_app.data.dto.request.SignUpRequestDto
 import com.moduro.barrier_free_app.domain.repository.AuthRepository
@@ -48,6 +49,18 @@ class AuthRepositoryImpl @Inject constructor(
                     username = username,
                     password = password
                 )
+            )
+            val result = response.result ?: throw Exception("result is null")
+
+            result
+        }
+    }
+
+    override suspend fun find(type: String, email: String): Result<JsonElement> {
+        return kotlin.runCatching {
+            val response = authDataSource.find(
+                type = type,
+                FindRequestDto(email = email)
             )
             val result = response.result ?: throw Exception("result is null")
 

--- a/app/src/main/java/com/moduro/barrier_free_app/data/repositoryimpl/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/repositoryimpl/AuthRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.moduro.barrier_free_app.data.dto.request.EmailRequestDto
 import com.moduro.barrier_free_app.data.dto.request.LoginRequestDto
 import com.moduro.barrier_free_app.data.dto.request.SignUpRequestDto
 import com.moduro.barrier_free_app.data.dto.request.VerifyRequestDto
+import com.moduro.barrier_free_app.data.dto.response.LoginResponseDto
 import com.moduro.barrier_free_app.domain.repository.AuthRepository
 import kotlinx.serialization.json.JsonElement
 import javax.inject.Inject
@@ -40,20 +41,15 @@ class AuthRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun login(
-        username: String,
-        password: String
-    ) : Result<JsonElement> {
+    override suspend fun login(dto: LoginRequestDto) : Result<LoginResponseDto> {
         return kotlin.runCatching {
-            val response = authDataSource.login(
-                LoginRequestDto(
-                    username = username,
-                    password = password
-                )
-            )
-            val result = response.result ?: throw Exception("result is null")
+            val response = authDataSource.login(dto)
 
-            result
+            if (response.isSuccess && response.result != null) {
+                response.result
+            } else {
+                throw IllegalStateException(response.message)
+            }
         }
     }
 

--- a/app/src/main/java/com/moduro/barrier_free_app/data/repositoryimpl/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/repositoryimpl/AuthRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.moduro.barrier_free_app.data.repositoryimpl
 
 import com.moduro.barrier_free_app.data.datasource.AuthDataSource
+import com.moduro.barrier_free_app.data.dto.request.LoginRequestDto
 import com.moduro.barrier_free_app.data.dto.request.SignUpRequestDto
 import com.moduro.barrier_free_app.domain.repository.AuthRepository
 import kotlinx.serialization.json.JsonElement
@@ -29,6 +30,23 @@ class AuthRepositoryImpl @Inject constructor(
                     verifyPassword = verifyPassword,
                     userType = userType,
                     userFacilityIds = userFacilityIds
+                )
+            )
+            val result = response.result ?: throw Exception("result is null")
+
+            result
+        }
+    }
+
+    override suspend fun login(
+        username: String,
+        password: String
+    ) : Result<JsonElement> {
+        return kotlin.runCatching {
+            val response = authDataSource.login(
+                LoginRequestDto(
+                    username = username,
+                    password = password
                 )
             )
             val result = response.result ?: throw Exception("result is null")

--- a/app/src/main/java/com/moduro/barrier_free_app/data/service/ApiKeyStorage.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/service/ApiKeyStorage.kt
@@ -6,4 +6,5 @@ object ApiKeyStorage {
     const val USERS = "users"
     const val AUTH = "auth"
     const val ME = "me"
+    const val SIGNUP = "signup"
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/data/service/ApiKeyStorage.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/service/ApiKeyStorage.kt
@@ -7,4 +7,5 @@ object ApiKeyStorage {
     const val AUTH = "auth"
     const val ME = "me"
     const val SIGNUP = "signup"
+    const val LOGIN = "login"
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/data/service/ApiKeyStorage.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/service/ApiKeyStorage.kt
@@ -9,4 +9,7 @@ object ApiKeyStorage {
     const val SIGNUP = "signup"
     const val LOGIN = "login"
     const val FIND = "find"
+    const val EMAIL = "email"
+    const val VERIFY = "verify"
+    const val SEND = "send"
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/data/service/ApiKeyStorage.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/service/ApiKeyStorage.kt
@@ -8,4 +8,5 @@ object ApiKeyStorage {
     const val ME = "me"
     const val SIGNUP = "signup"
     const val LOGIN = "login"
+    const val FIND = "find"
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/data/service/AuthApiService.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/service/AuthApiService.kt
@@ -1,13 +1,17 @@
 package com.moduro.barrier_free_app.data.service
 
 import com.moduro.barrier_free_app.data.dto.ModuroBaseResponse
-import com.moduro.barrier_free_app.data.dto.request.FindRequestDto
+import com.moduro.barrier_free_app.data.dto.request.EmailRequestDto
 import com.moduro.barrier_free_app.data.dto.request.LoginRequestDto
 import com.moduro.barrier_free_app.data.dto.request.SignUpRequestDto
+import com.moduro.barrier_free_app.data.dto.request.VerifyRequestDto
 import com.moduro.barrier_free_app.data.service.ApiKeyStorage.AUTH
+import com.moduro.barrier_free_app.data.service.ApiKeyStorage.EMAIL
 import com.moduro.barrier_free_app.data.service.ApiKeyStorage.FIND
 import com.moduro.barrier_free_app.data.service.ApiKeyStorage.LOGIN
+import com.moduro.barrier_free_app.data.service.ApiKeyStorage.SEND
 import com.moduro.barrier_free_app.data.service.ApiKeyStorage.SIGNUP
+import com.moduro.barrier_free_app.data.service.ApiKeyStorage.VERIFY
 import kotlinx.serialization.json.JsonElement
 import retrofit2.http.Body
 import retrofit2.http.POST
@@ -28,6 +32,16 @@ interface AuthApiService {
     @POST("/$AUTH/$FIND")
     suspend fun find(
         @Query("type") type: String,
-        @Body findRequestDto: FindRequestDto
+        @Body emailRequestDto: EmailRequestDto
+    ) : ModuroBaseResponse<JsonElement>
+
+    @POST("/$AUTH/$EMAIL/$SEND")
+    suspend fun send(
+        @Body emailRequestDto: EmailRequestDto
+    ) : ModuroBaseResponse<JsonElement>
+
+    @POST("/$AUTH/$EMAIL/$VERIFY")
+    suspend fun verify(
+        @Body verifyRequestDto: VerifyRequestDto
     ) : ModuroBaseResponse<JsonElement>
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/data/service/AuthApiService.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/service/AuthApiService.kt
@@ -1,14 +1,17 @@
 package com.moduro.barrier_free_app.data.service
 
 import com.moduro.barrier_free_app.data.dto.ModuroBaseResponse
+import com.moduro.barrier_free_app.data.dto.request.FindRequestDto
 import com.moduro.barrier_free_app.data.dto.request.LoginRequestDto
 import com.moduro.barrier_free_app.data.dto.request.SignUpRequestDto
 import com.moduro.barrier_free_app.data.service.ApiKeyStorage.AUTH
+import com.moduro.barrier_free_app.data.service.ApiKeyStorage.FIND
 import com.moduro.barrier_free_app.data.service.ApiKeyStorage.LOGIN
 import com.moduro.barrier_free_app.data.service.ApiKeyStorage.SIGNUP
 import kotlinx.serialization.json.JsonElement
 import retrofit2.http.Body
 import retrofit2.http.POST
+import retrofit2.http.Query
 
 interface AuthApiService {
 
@@ -20,5 +23,11 @@ interface AuthApiService {
     @POST("/$AUTH/$LOGIN")
     suspend fun login(
         @Body loginRequestDto: LoginRequestDto
+    ) : ModuroBaseResponse<JsonElement>
+
+    @POST("/$AUTH/$FIND")
+    suspend fun find(
+        @Query("type") type: String,
+        @Body findRequestDto: FindRequestDto
     ) : ModuroBaseResponse<JsonElement>
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/data/service/AuthApiService.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/service/AuthApiService.kt
@@ -1,16 +1,24 @@
 package com.moduro.barrier_free_app.data.service
 
 import com.moduro.barrier_free_app.data.dto.ModuroBaseResponse
+import com.moduro.barrier_free_app.data.dto.request.LoginRequestDto
 import com.moduro.barrier_free_app.data.dto.request.SignUpRequestDto
 import com.moduro.barrier_free_app.data.service.ApiKeyStorage.AUTH
+import com.moduro.barrier_free_app.data.service.ApiKeyStorage.LOGIN
 import com.moduro.barrier_free_app.data.service.ApiKeyStorage.SIGNUP
 import kotlinx.serialization.json.JsonElement
 import retrofit2.http.Body
 import retrofit2.http.POST
 
 interface AuthApiService {
+
     @POST("/$AUTH/$SIGNUP")
     suspend fun signup(
         @Body signUpRequestDto: SignUpRequestDto
+    ) : ModuroBaseResponse<JsonElement>
+
+    @POST("/$AUTH/$LOGIN")
+    suspend fun login(
+        @Body loginRequestDto: LoginRequestDto
     ) : ModuroBaseResponse<JsonElement>
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/data/service/AuthApiService.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/service/AuthApiService.kt
@@ -1,0 +1,16 @@
+package com.moduro.barrier_free_app.data.service
+
+import com.moduro.barrier_free_app.data.dto.ModuroBaseResponse
+import com.moduro.barrier_free_app.data.dto.request.SignUpRequestDto
+import com.moduro.barrier_free_app.data.service.ApiKeyStorage.AUTH
+import com.moduro.barrier_free_app.data.service.ApiKeyStorage.SIGNUP
+import kotlinx.serialization.json.JsonElement
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface AuthApiService {
+    @POST("/$AUTH/$SIGNUP")
+    suspend fun signup(
+        @Body signUpRequestDto: SignUpRequestDto
+    ) : ModuroBaseResponse<JsonElement>
+}

--- a/app/src/main/java/com/moduro/barrier_free_app/data/service/AuthApiService.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/service/AuthApiService.kt
@@ -5,6 +5,7 @@ import com.moduro.barrier_free_app.data.dto.request.EmailRequestDto
 import com.moduro.barrier_free_app.data.dto.request.LoginRequestDto
 import com.moduro.barrier_free_app.data.dto.request.SignUpRequestDto
 import com.moduro.barrier_free_app.data.dto.request.VerifyRequestDto
+import com.moduro.barrier_free_app.data.dto.response.LoginResponseDto
 import com.moduro.barrier_free_app.data.service.ApiKeyStorage.AUTH
 import com.moduro.barrier_free_app.data.service.ApiKeyStorage.EMAIL
 import com.moduro.barrier_free_app.data.service.ApiKeyStorage.FIND
@@ -28,7 +29,7 @@ interface AuthApiService {
     @POST("/$AUTH/$LOGIN")
     suspend fun login(
         @Body loginRequestDto: LoginRequestDto
-    ) : ModuroBaseResponse<JsonElement>
+    ) : ModuroBaseResponse<LoginResponseDto>
 
     @POST("/$AUTH/$FIND")
     suspend fun find(

--- a/app/src/main/java/com/moduro/barrier_free_app/data/service/AuthApiService.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/data/service/AuthApiService.kt
@@ -14,6 +14,7 @@ import com.moduro.barrier_free_app.data.service.ApiKeyStorage.SIGNUP
 import com.moduro.barrier_free_app.data.service.ApiKeyStorage.VERIFY
 import kotlinx.serialization.json.JsonElement
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Query
 
@@ -43,5 +44,11 @@ interface AuthApiService {
     @POST("/$AUTH/$EMAIL/$VERIFY")
     suspend fun verify(
         @Body verifyRequestDto: VerifyRequestDto
+    ) : ModuroBaseResponse<JsonElement>
+
+    @GET("/$AUTH/$SIGNUP/$VERIFY")
+    suspend fun duplicate(
+        @Query("type") type: String,
+        @Query("input") input: String
     ) : ModuroBaseResponse<JsonElement>
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/domain/repository/AuthRepository.kt
@@ -32,4 +32,9 @@ interface AuthRepository {
         email: String,
         verificationCode: String
     ) : Result<JsonElement>
+
+    suspend fun duplicate(
+        type: String,
+        input: String
+    ) : Result<JsonElement>
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/domain/repository/AuthRepository.kt
@@ -1,0 +1,16 @@
+package com.moduro.barrier_free_app.domain.repository
+
+import kotlinx.serialization.json.JsonElement
+
+interface AuthRepository {
+
+    suspend fun signup(
+        email: String,
+        nickname: String,
+        username: String,
+        password: String,
+        verifyPassword: String,
+        userType: String,
+        userFacilityIds: List<Int>
+    ) : Result<JsonElement>
+}

--- a/app/src/main/java/com/moduro/barrier_free_app/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/domain/repository/AuthRepository.kt
@@ -1,8 +1,10 @@
 package com.moduro.barrier_free_app.domain.repository
 
+import com.moduro.barrier_free_app.data.dto.request.LoginRequestDto
+import com.moduro.barrier_free_app.data.dto.response.LoginResponseDto
 import kotlinx.serialization.json.JsonElement
 
-interface AuthRepository {
+interface AuthRepository{
 
     suspend fun signup(
         email: String,
@@ -14,10 +16,7 @@ interface AuthRepository {
         userFacilityIds: List<Int>
     ) : Result<JsonElement>
 
-    suspend fun login(
-        username: String,
-        password: String
-    ) : Result<JsonElement>
+    suspend fun login(dto: LoginRequestDto) : Result<LoginResponseDto>
 
     suspend fun find(
         type: String,

--- a/app/src/main/java/com/moduro/barrier_free_app/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/domain/repository/AuthRepository.kt
@@ -23,4 +23,13 @@ interface AuthRepository {
         type: String,
         email: String
     ) : Result<JsonElement>
+
+    suspend fun send(
+        email: String
+    ) : Result<JsonElement>
+
+    suspend fun verify(
+        email: String,
+        verificationCode: String
+    ) : Result<JsonElement>
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/domain/repository/AuthRepository.kt
@@ -13,4 +13,9 @@ interface AuthRepository {
         userType: String,
         userFacilityIds: List<Int>
     ) : Result<JsonElement>
+
+    suspend fun login(
+        username: String,
+        password: String
+    ) : Result<JsonElement>
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/domain/repository/AuthRepository.kt
@@ -18,4 +18,9 @@ interface AuthRepository {
         username: String,
         password: String
     ) : Result<JsonElement>
+
+    suspend fun find(
+        type: String,
+        email: String
+    ) : Result<JsonElement>
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/presentation/auth/navigation/AuthNavGraph.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/presentation/auth/navigation/AuthNavGraph.kt
@@ -24,7 +24,8 @@ fun NavGraphBuilder.authNavGraph(
     composable(route = "find-account") {
         FindAccountRoute(navigator = navigator)
     }
-    composable(route = "signup-info") {
-        SignUpSettingRoute(navigator = navigator)
+    composable(route = "signup-info/{email}") { backStackEntry ->
+        val email = backStackEntry.arguments?.getString("email") ?: ""
+        SignUpSettingRoute(navigator = navigator, email = email)
     }
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/presentation/auth/navigation/AuthNavigator.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/presentation/auth/navigation/AuthNavigator.kt
@@ -25,7 +25,7 @@ class AuthNavigator(
         navController.navigate("find-account") {
         }
     }
-    fun navigateToSignUpSetting() {
-        navController.navigate("signup-info")
+    fun navigateToSignUpSetting(email: String) {
+        navController.navigate("signup-info/$email")
     }
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/presentation/auth/screen/FindAccountScreen.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/presentation/auth/screen/FindAccountScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.moduro.barrier_free_app.core_ui.component.CommonTopBar
 import com.moduro.barrier_free_app.core_ui.component.SignUpTextField
 import com.moduro.barrier_free_app.core_ui.component.StartButton
@@ -35,7 +35,7 @@ import com.moduro.barrier_free_app.presentation.auth.navigation.AuthNavigator
 @Composable
 fun FindAccountRoute(
     navigator: AuthNavigator,
-    viewModel: FindAccountViewModel = viewModel()
+    viewModel: FindAccountViewModel = hiltViewModel()
 ) {
     FindAccountScreen(
         onBackClick = { navigator.navController.popBackStack() },
@@ -125,6 +125,7 @@ fun FindAccountScreen(
             enabled = viewModel.isEmailEntered,
             onClick = {
                 viewModel.onSubmit {
+
                     Toast.makeText(context,"전송이 완료되었어요!", Toast.LENGTH_SHORT).show()
                     onNavigateToLogin()
                 }

--- a/app/src/main/java/com/moduro/barrier_free_app/presentation/auth/screen/FindAccountViewModel.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/presentation/auth/screen/FindAccountViewModel.kt
@@ -1,15 +1,24 @@
 package com.moduro.barrier_free_app.presentation.auth.screen
 
+import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.moduro.barrier_free_app.domain.repository.AuthRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 enum class FindMode {
     ID, PASSWORD
 }
 
-class FindAccountViewModel: ViewModel() {
+@HiltViewModel
+class FindAccountViewModel @Inject constructor(
+    private val repository: AuthRepository
+): ViewModel() {
 
     var selectedMode by mutableStateOf(FindMode.ID)
     var email by mutableStateOf("")
@@ -30,7 +39,19 @@ class FindAccountViewModel: ViewModel() {
     }
 
     fun onSubmit(onSuccess: () -> Unit) {
-        //TODO 이메일 전송
-        onSuccess()
+        viewModelScope.launch {
+            val type = when (selectedMode) {
+                FindMode.ID -> "username"
+                FindMode.PASSWORD -> "password"
+            }
+
+            val result = repository.find(type, email)
+
+            result.onSuccess {
+                onSuccess()
+            }.onFailure {
+                Log.e("FindAccount", "계정 찾기 실패", it)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/presentation/auth/screen/LoginScreen.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/presentation/auth/screen/LoginScreen.kt
@@ -13,12 +13,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.moduro.barrier_free_app.core_ui.component.CommonTopBar
 import com.moduro.barrier_free_app.core_ui.component.LoginTextField
 import com.moduro.barrier_free_app.core_ui.component.StartButton
@@ -31,7 +29,7 @@ import com.moduro.barrier_free_app.presentation.auth.navigation.AuthNavigator
 @Composable
 fun LoginRoute(
     navigator: AuthNavigator,
-    viewModel: LoginViewModel = viewModel(),
+    viewModel: LoginViewModel = hiltViewModel(),
 ) {
     LoginScreen(
         viewModel = viewModel,
@@ -72,18 +70,18 @@ fun LoginScreen(
         LoginTextField(
             label = "이메일 주소",
             hint = "아이디 또는 이메일 주소",
-            text = viewModel.email,
+            text = viewModel.username,
             onValueChange = {
-                viewModel.email = it
-                viewModel.emailError = null
+                viewModel.username = it
+                viewModel.usernameError = null
             },
-            isError = viewModel.emailError != null,
-            errorMessage = viewModel.emailError
+            isError = viewModel.usernameError != null,
+            errorMessage = viewModel.usernameError
         )
 
-        if (viewModel.emailError != null) {
+        if (viewModel.usernameError != null) {
             Text(
-                text = viewModel.emailError!!,
+                text = viewModel.usernameError!!,
                 color = Warning,
                 style = typography.H7_M_5,
                 modifier = Modifier.padding(top = 7.dp, start = 16.dp)
@@ -145,25 +143,4 @@ fun LoginScreen(
             )
         }
     }
-}
-
-@Composable
-@Preview
-fun LoginPreview() {
-    val viewModel = remember {
-        LoginViewModel().apply {
-            email = ""
-            password = ""
-            emailError = "존재하지 않는 회원입니다."
-            passwordError = "비밀번호 오류입니다.\n5번 제한시 비밀번호 찾기가 필요합니다.(1/5)"
-        }
-    }
-
-    LoginScreen(
-        viewModel = viewModel,
-        onBackClick = {},
-        onLoginSuccess = {},
-        onSignUpClick = {},
-        onFindAccountClick = {}
-    )
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/presentation/auth/screen/LoginViewModel.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/presentation/auth/screen/LoginViewModel.kt
@@ -2,12 +2,10 @@ package com.moduro.barrier_free_app.presentation.auth.screen
 
 import android.content.SharedPreferences
 import android.util.Log
-import android.widget.Toast
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.moduro.barrier_free_app.data.dto.request.LoginRequestDto

--- a/app/src/main/java/com/moduro/barrier_free_app/presentation/auth/screen/LoginViewModel.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/presentation/auth/screen/LoginViewModel.kt
@@ -1,36 +1,84 @@
 package com.moduro.barrier_free_app.presentation.auth.screen
 
+import android.content.SharedPreferences
+import android.util.Log
+import android.widget.Toast
+import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.moduro.barrier_free_app.data.dto.request.LoginRequestDto
+import com.moduro.barrier_free_app.domain.repository.AuthRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-class LoginViewModel : ViewModel() {
-
-    var email by mutableStateOf("")
+@HiltViewModel
+class LoginViewModel @Inject constructor(
+    private val repository: AuthRepository,
+    private val preferences: SharedPreferences
+): ViewModel() {
+    var username by mutableStateOf("")
     var password by mutableStateOf("")
 
-    var emailError by mutableStateOf<String?>(null)
+    var usernameError by mutableStateOf<String?>(null)
     var passwordError by mutableStateOf<String?>(null)
 
     val isLoginEnabled: Boolean
-        get() = email.isNotBlank() && password.isNotBlank()
+        get() = username.isNotBlank() && password.isNotBlank()
 
+    private val _loginState = mutableStateOf<Boolean?>(null)
+    val loginState: State<Boolean?> = _loginState
+
+    private val _loginError = mutableStateOf<String?>(null)
+    val loginError : State<String?> = _loginError
+
+    // TODO 에러 메시지 세분화 .. 서버 오류는 로그로만 띄우기
     fun login(onSuccess: () -> Unit) {
-        if (email != "test@gmail.com") {
-            emailError = "존재하지 않는 회원입니다."
-            passwordError = null
+        if (username.isBlank()) {
+            usernameError = "아이디 혹은 이메일을 입력해주세요."
+            return
+        }
+        if (password.isBlank()) {
+            passwordError = "비밀번호를 입력해주세요."
             return
         }
 
-        if (password != "1234") {
-            emailError = null
-            passwordError = "비밀번호 오류입니다.\n5번 제한 시 비밀번호 찾기가 필요합니다." //TODO 비밀번호 몇번 틀렸는지 띄우기
-            return
-        }
+        val loginRequestDto = LoginRequestDto(username, password)
 
-        emailError = null
-        passwordError = null
-        onSuccess()
+        viewModelScope.launch {
+            val result = repository.login(loginRequestDto)
+
+            result.onSuccess { response ->
+                val token = response.accessToken
+                if (!token.isNullOrBlank()) {
+                    saveToken(token)
+                    onSuccess()
+                } else {
+                    passwordError = "서버 응답에 문제가 있어요. 다시 시도해주세요."
+                }
+            }.onFailure { exception ->
+                Log.e("LoginViewModel", "로그인 실패", exception)
+                passwordError = "서버 응답에 문제가 있어요. 다시 시도해주세요."
+            }
+        }
+    }
+
+    private fun saveToken(token : String){
+        preferences.edit()
+            .putString("USER_TOKEN", token)
+            .commit()
+
+        val savedToken = preferences.getString("USER_TOKEN", null)
+        Log.d("LoginViewModel", "Saved Token: $savedToken")
+
+    }
+
+    fun resetLoginState() {
+        _loginState.value = null
+        _loginError.value = null
     }
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/presentation/auth/screen/SignUpScreen.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/presentation/auth/screen/SignUpScreen.kt
@@ -1,5 +1,6 @@
 package com.moduro.barrier_free_app.presentation.auth.screen
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -10,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -39,6 +41,7 @@ fun SignUpScreen(
     onSignUpSuccess: () -> Unit
 ) {
     val typography = LocalbarrierFreeTypographyProvider.current
+    val context = LocalContext.current
 
     Column(
         modifier = Modifier
@@ -74,7 +77,11 @@ fun SignUpScreen(
                 value = "인증번호 요청하기",
                 enabled = viewModel.isSignUpEnabled,
                 onClick = {
-                    viewModel.currentStep = 2
+                    viewModel.sendVerificationCode(
+                        email = viewModel.email,
+                        onSuccess = { viewModel.currentStep = 2 },
+                        onFailure = { message -> Toast.makeText(context, message, Toast.LENGTH_SHORT).show()}
+                    )
                 },
                 modifier = Modifier
                     .fillMaxWidth()

--- a/app/src/main/java/com/moduro/barrier_free_app/presentation/auth/screen/SignUpScreen.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/presentation/auth/screen/SignUpScreen.kt
@@ -12,9 +12,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.moduro.barrier_free_app.core_ui.component.CommonTopBar
 import com.moduro.barrier_free_app.core_ui.component.SignUpTextField
 import com.moduro.barrier_free_app.core_ui.component.StartButton
@@ -25,12 +24,12 @@ import com.moduro.barrier_free_app.presentation.auth.navigation.AuthNavigator
 @Composable
 fun SignUpRoute(
     navigator: AuthNavigator,
-    viewModel: SignUpViewModel = viewModel()
+    viewModel: SignUpViewModel = hiltViewModel()
 ) {
     SignUpScreen(
         onBackClick = { navigator.navController.popBackStack() },
         viewModel = viewModel,
-        onSignUpSuccess = { navigator.navigateToSignUpSetting() }
+        onSignUpSuccess = { navigator.navigateToSignUpSetting(viewModel.inputEmail) }
     )
 }
 
@@ -64,9 +63,9 @@ fun SignUpScreen(
             SignUpTextField(
                 label = "이메일 주소",
                 hint = "아이디 또는 이메일 주소",
-                text = viewModel.email,
+                text = viewModel.inputEmail,
                 onValueChange = {
-                    viewModel.email = it
+                    viewModel.inputEmail = it
                 },
                 enabled = true
             )
@@ -78,7 +77,6 @@ fun SignUpScreen(
                 enabled = viewModel.isSignUpEnabled,
                 onClick = {
                     viewModel.sendVerificationCode(
-                        email = viewModel.email,
                         onSuccess = { viewModel.currentStep = 2 },
                         onFailure = { message -> Toast.makeText(context, message, Toast.LENGTH_SHORT).show()}
                     )
@@ -111,9 +109,9 @@ fun SignUpScreen(
             SignUpTextField(
                 label = "이메일 주소",
                 hint = "아이디 또는 이메일 주소",
-                text = viewModel.email,
+                text = viewModel.inputEmail,
                 onValueChange = {
-                    viewModel.email = it
+                    viewModel.inputEmail = it
                 },
                 enabled = false
             )
@@ -136,10 +134,7 @@ fun SignUpScreen(
                 value = "다음",
                 enabled = viewModel.isSignUpEnabled,
                 onClick = {
-                    //viewModel.signUp(onSignUpSuccess)
                     viewModel.verifyVerificationCode(
-                        email = viewModel.email,
-                        verificationCode = viewModel.verificationCode,
                         onSuccess = onSignUpSuccess,
                         onFailure = { message -> Toast.makeText(context, message, Toast.LENGTH_SHORT).show() }
                     )
@@ -150,14 +145,4 @@ fun SignUpScreen(
             )
         }
     }
-}
-
-@Composable
-@Preview
-fun SignUpPreview() {
-    SignUpScreen(
-        onBackClick = {},
-        viewModel = viewModel(),
-        onSignUpSuccess = {}
-    )
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/presentation/auth/screen/SignUpScreen.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/presentation/auth/screen/SignUpScreen.kt
@@ -136,8 +136,13 @@ fun SignUpScreen(
                 value = "다음",
                 enabled = viewModel.isSignUpEnabled,
                 onClick = {
-                    // 인증번호 확인
-                    viewModel.signUp(onSignUpSuccess)
+                    //viewModel.signUp(onSignUpSuccess)
+                    viewModel.verifyVerificationCode(
+                        email = viewModel.email,
+                        verificationCode = viewModel.verificationCode,
+                        onSuccess = onSignUpSuccess,
+                        onFailure = { message -> Toast.makeText(context, message, Toast.LENGTH_SHORT).show() }
+                    )
                 },
                 modifier = Modifier
                     .fillMaxWidth()

--- a/app/src/main/java/com/moduro/barrier_free_app/presentation/auth/screen/SignUpSettingScreen.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/presentation/auth/screen/SignUpSettingScreen.kt
@@ -1,5 +1,6 @@
 package com.moduro.barrier_free_app.presentation.auth.screen
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -16,6 +17,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -25,10 +27,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.moduro.barrier_free_app.core_ui.component.CommonTopBar
+import com.moduro.barrier_free_app.core_ui.component.IdDuplicateTextField
 import com.moduro.barrier_free_app.core_ui.component.ProfileFacilityChip
 import com.moduro.barrier_free_app.core_ui.component.ProfileNicknameField
 import com.moduro.barrier_free_app.core_ui.component.SignUpTextField
@@ -38,12 +43,18 @@ import com.moduro.barrier_free_app.core_ui.theme.LocalbarrierFreeTypographyProvi
 import com.moduro.barrier_free_app.core_ui.theme.Text4
 import com.moduro.barrier_free_app.core_ui.theme.Text5
 import com.moduro.barrier_free_app.presentation.auth.navigation.AuthNavigator
+import com.moduro.barrier_free_app.presentation.mypage.screen.NicknameChangeStatus
 
 @Composable
 fun SignUpSettingRoute(
     navigator: AuthNavigator,
-    viewModel: SignUpViewModel = viewModel()
+    viewModel: SignUpViewModel = hiltViewModel(),
+    email: String
 ) {
+    LaunchedEffect(Unit) {
+        viewModel.setEmail(email)
+    }
+
     SignUpSettingScreen(
         onBackClick = { navigator.navController.popBackStack() },
         onNavigateToMain = { navigator.navigateToMain() },
@@ -65,7 +76,14 @@ fun SignUpSettingScreen(
     }
 
     val typography = LocalbarrierFreeTypographyProvider.current
+    val current = LocalContext.current
+
+    val nicknameChangeStatus by viewModel.nicknameChangeStatus.collectAsState()
+    val idStatus by viewModel.idStatus.collectAsState()
+
     var nicknameInput by remember { mutableStateOf("") }
+    var idInput by remember { mutableStateOf("") }
+
     val userInfo = viewModel.userInfo.collectAsState().value
 
     val selectedUserTypes = remember {
@@ -100,21 +118,83 @@ fun SignUpSettingScreen(
                 text = nicknameInput,
                 onValueChange = { nicknameInput = it },
                 onCheckDuplicateClick = {
-                    viewModel.setNickname(nicknameInput)
+                    viewModel.checkDuplicate(
+                        type = "nickname",
+                        input = nicknameInput,
+                        onSuccess = { viewModel.setNicknameChangeStatus(NicknameChangeStatus.SUCCESS) },
+                        onFailure = { viewModel.setNicknameChangeStatus(NicknameChangeStatus.DUPLICATE) }
+                    )
                 }
             )
 
+            Spacer(modifier = Modifier.height(10.dp))
+
+            when (nicknameChangeStatus) {
+                NicknameChangeStatus.SUCCESS -> {
+                    Text(
+                        text = "사용 가능한 닉네임 입니다.",
+                        color = Color(0xFF023DFF),
+                        style = typography.H7_M_5,
+                        modifier = Modifier.padding(top = 4.dp)
+                    )
+                }
+
+                NicknameChangeStatus.DUPLICATE -> {
+                    Text(
+                        text = "이미 존재하는 닉네임 입니다.",
+                        color =  Color(0xFFF00000),
+                        style = typography.H7_M_5,
+                        modifier = Modifier.padding(top = 4.dp)
+                    )
+                }
+
+                else -> {}
+            }
+
             Spacer(modifier = Modifier.height(40.dp))
 
-            SignUpTextField(
+            IdDuplicateTextField(
                 label = "아이디",
                 hint = "아이디(영문+숫자 6~16자)",
-                text = viewModel.id,
+                text = idInput,
                 onValueChange = {
+                    idInput = it
                     viewModel.id = it
+                },
+                onCheckDuplicateClick = {
+                    viewModel.checkDuplicate(
+                        type = "username",
+                        input = idInput,
+                        onSuccess = { viewModel.setIdStatus(NicknameChangeStatus.SUCCESS) },
+                        onFailure = { viewModel.setIdStatus(NicknameChangeStatus.DUPLICATE) }
+                    )
                 },
                 enabled = true
             )
+
+            Spacer(modifier = Modifier.height(10.dp))
+
+            when (idStatus) {
+                NicknameChangeStatus.SUCCESS -> {
+                    Text(
+                        text = "사용 가능한 아이디 입니다.",
+                        color = Color(0xFF023DFF),
+                        style = typography.H7_M_5,
+                        modifier = Modifier.padding(top = 4.dp)
+                    )
+                }
+
+                NicknameChangeStatus.DUPLICATE -> { //TODO 유효 길이 준수, 형식 준수 등 예외 처리 추가
+                    Text(
+                        text = "이미 존재하는 아이디 입니다",
+                        color =  Color(0xFFF00000),
+                        style = typography.H7_M_5,
+                        modifier = Modifier.padding(top = 4.dp)
+                    )
+                }
+
+                else -> {}
+            }
 
             Spacer(modifier = Modifier.height(10.dp))
 
@@ -130,6 +210,7 @@ fun SignUpSettingScreen(
 
             Spacer(modifier = Modifier.height(40.dp))
 
+            // TODO 사용자 미 선택시 선택하도록 막기
             Text(
                 text = "사용자 유형 설정",
                 style = typography.H5_SB_5,
@@ -141,8 +222,10 @@ fun SignUpSettingScreen(
                     ProfileFacilityChip(
                         label = label,
                         isSelected = selectedUserTypes.contains(label) ||
-                                (selectedUserTypes.contains("전체") && label != "전체"),
-                        onClick = { toggleSelection(selectedUserTypes, label) }
+                                (selectedUserTypes.contains("전체") &&
+                                        label in listOf("휠체어 사용자", "영유아 동반"))
+                        ,
+                        onClick = { toggleUserTypeSelection(selectedUserTypes, label) }
                     )
                 }
             }
@@ -165,16 +248,46 @@ fun SignUpSettingScreen(
                     ProfileFacilityChip(
                         label = label,
                         isSelected = selectedFacilities.contains(label) ||
-                                (selectedFacilities.contains("전체") && label != "전체"),
-                        onClick = { toggleSelection(selectedFacilities, label) }
+                                (selectedFacilities.contains("전체") && label in facilityLabels)
+                        ,
+                        onClick = { toggleFacilitySelection(selectedFacilities, label) }
                     )
                 }
             }
 
-            Spacer(modifier = Modifier.height(70.dp))
+            Spacer(modifier = Modifier.height(45.dp))
 
             Button(
-                onClick = { onNavigateToMain() },
+                onClick = {
+                    val mappedUserType = when {
+                        selectedUserTypes.contains("전체") ||
+                                selectedUserTypes.containsAll(listOf("휠체어 사용자", "영유아 동반")) -> "ALL"
+                        selectedUserTypes.contains("휠체어 사용자") -> "DISABLED"
+                        selectedUserTypes.contains("영유아 동반") -> "PREGNANT"
+                        else -> "ALL"
+                    }
+
+
+                    viewModel.submitSignUpSetting(
+                        email = viewModel.inputEmail,
+                        nickname = nicknameInput,
+                        username = viewModel.id,
+                        password = viewModel.password,
+                        verifyPassword = viewModel.password,
+                        userType = mappedUserType,
+                        userFacilityIds = if (selectedFacilities.contains("전체")) {
+                            listOf(1, 2, 3, 4, 5)
+                        } else {
+                            selectedFacilities.mapNotNull { labelToFacilityId(it) }
+                        },
+                        onSuccess = { onNavigateToMain() },
+                        onFailure = { message ->
+                            Toast
+                                .makeText(current, message, Toast.LENGTH_SHORT)
+                                .show()
+                        }
+                    )
+                },
                 shape = RoundedCornerShape(10.dp),
                 colors = ButtonDefaults.buttonColors(
                     containerColor = Text5,
@@ -191,14 +304,49 @@ fun SignUpSettingScreen(
 }
 
 
-fun toggleSelection(list: SnapshotStateList<String>, item: String) {
+fun toggleUserTypeSelection(list: SnapshotStateList<String>, item: String) {
     if (item == "전체") {
         list.clear()
         list.add("전체")
     } else {
-        if (list.contains("전체")) list.remove("전체")
+        list.remove("전체")
+        if (list.contains(item)) list.remove(item) else list.add(item)
 
-        if (list.contains(item)) list.remove(item)
-        else list.add(item)
+        // 조건: 둘 다 선택되었으면 '전체'로 간주
+        if (list.contains("휠체어 사용자") && list.contains("영유아 동반")) {
+            list.clear()
+            list.add("전체")
+        }
     }
 }
+
+val facilityLabels = listOf("🛗 승강기", "♿ 장애인화장실", "👶 영유아동반", "🛁 수유실", "🧑‍🦽경사로")
+
+fun toggleFacilitySelection(list: SnapshotStateList<String>, item: String) {
+    if (item == "전체") {
+        list.clear()
+        list.addAll(listOf("전체") + facilityLabels)
+    } else {
+        list.remove("전체")
+        if (list.contains(item)) list.remove(item) else list.add(item)
+
+        // 모든 항목 선택되면 '전체' 추가
+        if (facilityLabels.all { list.contains(it) }) {
+            if (!list.contains("전체")) list.add("전체")
+        } else {
+            list.remove("전체")
+        }
+    }
+}
+
+fun labelToFacilityId(label: String): Int? {
+    return when (label) {
+        "🛗 승강기" -> 1
+        "♿ 장애인화장실" -> 2
+        "👶 영유아동반" -> 3
+        "🛁 수유실" -> 4
+        "🧑‍🦽경사로" -> 5
+        else -> null
+    }
+}
+

--- a/app/src/main/java/com/moduro/barrier_free_app/presentation/auth/screen/SignUpViewModel.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/presentation/auth/screen/SignUpViewModel.kt
@@ -4,12 +4,19 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.moduro.barrier_free_app.domain.repository.AuthRepository
 import com.moduro.barrier_free_app.presentation.mypage.screen.UserInfo
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-class SignUpViewModel : ViewModel() {
-
+@HiltViewModel
+class SignUpViewModel @Inject constructor(
+    private val authRepository: AuthRepository
+): ViewModel() {
     private val _userInfo = MutableStateFlow<UserInfo?>(null)
     val userInfo: StateFlow<UserInfo?> = _userInfo
 
@@ -32,5 +39,17 @@ class SignUpViewModel : ViewModel() {
 
     fun setNickname(nicknameInput: String) {
         // TODO: 닉네임 중복 확인 API 호출
+    }
+
+    fun sendVerificationCode(
+        email: String,
+        onSuccess: () -> Unit,
+        onFailure: (String) -> Unit
+    ) {
+        viewModelScope.launch {
+            val result = authRepository.send(email)
+            if (result.isSuccess) onSuccess()
+            else onFailure(result.exceptionOrNull()?.message ?: "전송 실패")
+        }
     }
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/presentation/auth/screen/SignUpViewModel.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/presentation/auth/screen/SignUpViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.moduro.barrier_free_app.domain.repository.AuthRepository
+import com.moduro.barrier_free_app.presentation.mypage.screen.NicknameChangeStatus
 import com.moduro.barrier_free_app.presentation.mypage.screen.UserInfo
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -20,7 +21,7 @@ class SignUpViewModel @Inject constructor(
     private val _userInfo = MutableStateFlow<UserInfo?>(null)
     val userInfo: StateFlow<UserInfo?> = _userInfo
 
-    var email by mutableStateOf("")
+    var inputEmail by mutableStateOf("")
     var verificationCode by mutableStateOf("")
     var id by mutableStateOf("")
     var password by mutableStateOf("")
@@ -28,34 +29,98 @@ class SignUpViewModel @Inject constructor(
     var currentStep by mutableStateOf(1)
 
     val isSignUpEnabled: Boolean
-        get() = email.isNotBlank()
+        get() = inputEmail.isNotBlank()
 
-    fun setNickname(nicknameInput: String) {
-        // TODO: 닉네임 중복 확인 API 호출
+    fun setEmail(email: String) {
+        this.inputEmail = email
     }
 
-    fun sendVerificationCode(
-        email: String,
+    fun setNicknameChangeStatus(status: NicknameChangeStatus) {
+        _nicknameChangeStatus.value = status
+    }
+
+    fun setIdStatus(status: NicknameChangeStatus) {
+        _idStatus.value = status
+    }
+
+    private val _nicknameChangeStatus = MutableStateFlow(NicknameChangeStatus.NONE)
+    val nicknameChangeStatus: StateFlow<NicknameChangeStatus> = _nicknameChangeStatus
+
+    private val _idStatus = MutableStateFlow<NicknameChangeStatus>(NicknameChangeStatus.NONE)
+    val idStatus: StateFlow<NicknameChangeStatus> = _idStatus
+
+    fun checkDuplicate(
+        type: String,
+        input: String,
         onSuccess: () -> Unit,
         onFailure: (String) -> Unit
     ) {
         viewModelScope.launch {
-            val result = authRepository.send(email)
+            val result = authRepository.duplicate(type, input)
+            if (result.isSuccess) {
+                when (type) {
+                    "nickname" -> _nicknameChangeStatus.value = NicknameChangeStatus.SUCCESS
+                    "username" -> _idStatus.value = NicknameChangeStatus.SUCCESS
+                }
+                onSuccess()
+            } else {
+                when (type) {
+                    "nickname" -> _nicknameChangeStatus.value = NicknameChangeStatus.DUPLICATE
+                    "username" -> _idStatus.value = NicknameChangeStatus.DUPLICATE
+                }
+                onFailure(result.exceptionOrNull()?.message?: "중복 확인 실패")
+            }
+        }
+    }
+
+    fun sendVerificationCode(
+        onSuccess: () -> Unit,
+        onFailure: (String) -> Unit
+    ) {
+        viewModelScope.launch {
+            val result = authRepository.send(inputEmail)
             if (result.isSuccess) onSuccess()
-            else onFailure(result.exceptionOrNull()?.message ?: "전송 실패, 다시 시도해 주세요")
+            else onFailure(result.exceptionOrNull()?.message ?: "전송 실패")
         }
     }
 
     fun verifyVerificationCode(
-        email: String,
-        verificationCode: String,
         onSuccess: () -> Unit,
         onFailure: (String) -> Unit
     ) {
         viewModelScope.launch {
-            val result = authRepository.verify(email, verificationCode)
+            val result = authRepository.verify(inputEmail, verificationCode)
             if (result.isSuccess) onSuccess()
-            else onFailure(result.exceptionOrNull()?.message ?: "인증 실패, 다시 시도해 주세요")
+            else onFailure(result.exceptionOrNull()?.message ?: "인증 실패")
+        }
+    }
+
+    fun submitSignUpSetting(
+        email: String,
+        nickname: String,
+        username: String,
+        password: String,
+        verifyPassword: String,
+        userType: String,
+        userFacilityIds: List<Int>,
+        onSuccess: () -> Unit,
+        onFailure: (String) -> Unit
+    ) {
+        viewModelScope.launch {
+            val result = authRepository.signup(
+                email = email,
+                nickname = nickname,
+                username = username,
+                password = password,
+                verifyPassword = verifyPassword,
+                userType = userType,
+                userFacilityIds = userFacilityIds
+            )
+            if (result.isSuccess) {
+                onSuccess()
+            } else {
+                onFailure(result.exceptionOrNull()?.message ?: "회원가입 실패")
+            }
         }
     }
 }

--- a/app/src/main/java/com/moduro/barrier_free_app/presentation/auth/screen/SignUpViewModel.kt
+++ b/app/src/main/java/com/moduro/barrier_free_app/presentation/auth/screen/SignUpViewModel.kt
@@ -30,13 +30,6 @@ class SignUpViewModel @Inject constructor(
     val isSignUpEnabled: Boolean
         get() = email.isNotBlank()
 
-    val isEmailValid: Boolean
-        get() = android.util.Patterns.EMAIL_ADDRESS.matcher(email).matches()
-
-    fun signUp(onSuccess: () -> Unit) {
-        onSuccess()
-    }
-
     fun setNickname(nicknameInput: String) {
         // TODO: 닉네임 중복 확인 API 호출
     }
@@ -49,7 +42,20 @@ class SignUpViewModel @Inject constructor(
         viewModelScope.launch {
             val result = authRepository.send(email)
             if (result.isSuccess) onSuccess()
-            else onFailure(result.exceptionOrNull()?.message ?: "전송 실패")
+            else onFailure(result.exceptionOrNull()?.message ?: "전송 실패, 다시 시도해 주세요")
+        }
+    }
+
+    fun verifyVerificationCode(
+        email: String,
+        verificationCode: String,
+        onSuccess: () -> Unit,
+        onFailure: (String) -> Unit
+    ) {
+        viewModelScope.launch {
+            val result = authRepository.verify(email, verificationCode)
+            if (result.isSuccess) onSuccess()
+            else onFailure(result.exceptionOrNull()?.message ?: "인증 실패, 다시 시도해 주세요")
         }
     }
 }


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
_소셜로그인 제외한 Auth API 연동 완료_ 
- 회원가입 API 연동
- 로그인 API 연동
- 아이디/비밀번호 API 연동
- 닉네임/아이디 중복확인 API 연동
- 이메일 인증코드 발송 API 연동 
- 이메일 인증코드 확인 API 연동 

🌱 PR 포인트
- 추후에 리팩토링하면서 에러 메시지를 더 세분화시키고 정리하면 좋을 것 같아용 
- SharedPreferences 관련 오류 발생해서 RetrofitModule class에 수정사항 있습니다 ..! 

## 📸 스크린샷
화면 녹화본은 회원가입부터 쭉 녹화하려고 하는데 제가 연동하면서 가진 계정들을 다 사용해서 😅 백에서 회원 삭제해주시면 쭉 찍어서 업로드해놓겠습니다 
선희님에게 회원db에서 삭제해달라고 요청해두었습니다 !

## 📮 관련 이슈
- #36 